### PR TITLE
update manifest.json

### DIFF
--- a/latest/manifest.json
+++ b/latest/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "modded jaket",
     "description": "jaket but better ong",
-    "version_number": "1.3.42.1",
+    "version_number": "1.3.421",
     "website_url": "https://github.com/Glitch31415/modded-jaket2",
     "dependencies": []
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "modded jaket",
     "description": "jaket but better ong",
-    "version_number": "1.3.42.1",
+    "version_number": "1.3.421",
     "website_url": "https://github.com/Glitch31415/modded-jaket2",
     "dependencies": []
 }


### PR DESCRIPTION
r2modman, and probably thunderstore as well, don't like 4 numbered versions, so instead of 1.3.42.1 in manifest.json, its 1.3.421, because it gets the same idea across without causing some issues with r2